### PR TITLE
Old instructions for Zone export

### DIFF
--- a/content/articles/zone-export.markdown
+++ b/content/articles/zone-export.markdown
@@ -18,9 +18,9 @@ The exported data follows the BIND zone file format.
 
 1.  Log into your DNSimple account.
 1.  On the top-nav menu click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
-1.  On the right sidebar, under <label>Task</label>, click on the <label>Export Zone</label> link.
+1.  On the right sidebar, under <label>Settings</label>, click on the <label>Export to a zone file</label> link.
 
-    ![Export Zone link](http://cl.ly/image/1H2F1o143D1q/dnsimple-zone-export.png)
+    ![Export Zone link](http://cl.ly/image/0G301B0z3c0S/export-import-zone.png)
 
 1. The link will open a text zone file. Save the file to your computer.
 


### PR DESCRIPTION
This fixes the old screenshot and matches the copy to the correct links.