### PR TITLE
Add note about Secondary DNS

### DIFF
--- a/content/articles/domain-resolution-issues.markdown
+++ b/content/articles/domain-resolution-issues.markdown
@@ -78,7 +78,7 @@ ns1.thirdparty.com.
 ns2.thirdparty.com.
 ~~~
 
-This configuration may lead to random DNS resolution issue, especially if you are using DNS custom features such as ALIAS or URL records and/or the two DNS services are not in sync.
+This configuration may lead to random DNS resolution issues, especially if you are using DNS custom features such as ALIAS or URL records and/or the two DNS services are not in sync.
 
 <info>
 When you have Secondary DNS enabled your domain **should not** be pointing only to DNSimple name servers: both DNSimple name servers and your Secondary DNS provider's name servers should be listed.

--- a/content/articles/domain-resolution-issues.markdown
+++ b/content/articles/domain-resolution-issues.markdown
@@ -78,7 +78,7 @@ ns1.thirdparty.com.
 ns2.thirdparty.com.
 ~~~
 
-This configuration may lead to random DNS resolution issue, especially if you are using DNS custom features such as ALIAS or URL records and/or the two DNS services are not in sync. 
+This configuration may lead to random DNS resolution issue, especially if you are using DNS custom features such as ALIAS or URL records and/or the two DNS services are not in sync.
 
 
 ## Check name server list in the WHOIS response

--- a/content/articles/domain-resolution-issues.markdown
+++ b/content/articles/domain-resolution-issues.markdown
@@ -80,6 +80,10 @@ ns2.thirdparty.com.
 
 This configuration may lead to random DNS resolution issue, especially if you are using DNS custom features such as ALIAS or URL records and/or the two DNS services are not in sync.
 
+<info>
+When you have Secondary DNS enabled your domain **should not** be pointing only to DNSimple name servers: both DNSimple name servers and your Secondary DNS provider's name servers should be listed.
+</info>
+
 
 ## Check name server list in the WHOIS response
 


### PR DESCRIPTION
A customer was confused about this bit as he was considering his setup incorrect despite having Secondary DNS enabled:

> 2. When I run `dig NS smockle.com +short` I see “c.ns.buddyns.com.” in addition to the four DNSimple name servers. This page: https://support.dnsimple.com/articles/domain-resolution-issues/ lists that as a problem.

I have added a small note clarifying that it doesn't apply to domains with Secondary DNS.