### PR TITLE
Typography & cosmetic improvements

### DIFF
--- a/content/assets/bootstrap/config.json
+++ b/content/assets/bootstrap/config.json
@@ -1,6 +1,5 @@
 {
   "vars": {
-    "@font-family-sans-serif": "\"Open Sans\", Helvetica, Arial, sans-serif",
     "@font-family-monospace": "Consolas, Menlo, \"Liberation Mono\", \"Courier New\", monospace"
   },
   "css": [

--- a/content/assets/bootstrap/css/bootstrap.css
+++ b/content/assets/bootstrap/css/bootstrap.css
@@ -37,7 +37,6 @@ template {
   display: none;
 }
 html {
-  font-family: sans-serif;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
 }
@@ -261,13 +260,9 @@ table {
   box-sizing: border-box;
 }
 html {
-  font-size: 62.5%;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 body {
-  font-family: "Open Sans", Helvetica, Arial, sans-serif;
-  font-size: 14px;
-  line-height: 1.428571429;
   color: #333333;
   background-color: #ffffff;
 }
@@ -347,8 +342,6 @@ h6,
 .h4,
 .h5,
 .h6 {
-  font-family: "Open Sans", Helvetica, Arial, sans-serif;
-  font-weight: 500;
   line-height: 1.1;
   color: inherit;
 }

--- a/content/assets/css/_application.scss
+++ b/content/assets/css/_application.scss
@@ -137,11 +137,6 @@ h2 {
   }
 }
 
-#main #toc {
-  font-size: 30px;
-}
-
-
 // Header
 // -------------------------
 
@@ -149,19 +144,6 @@ h2 {
   display: inline-block;
   width: auto;
 }
-
-
-// Main
-// -------------------------
-
-// Make the first title of the page more prominent.
-#main > h1 {
-  // .page-header
-  padding-bottom: 9px;
-  margin: 40px 0 20px;
-  border-bottom: 1px solid #eeeeee;
-}
-
 
 // Sidebar
 // -------------------------

--- a/content/assets/css/_application.scss
+++ b/content/assets/css/_application.scss
@@ -190,10 +190,9 @@ h2 {
 }
 .nav-list li a:hover,
 .nav-list li.active a {
-  color: #cc8b00;
-  border-left: 5px solid #cc8b00;
+  color: $accent-color;
+  border-left: 5px solid $accent-color;
 }
-
 
 .articles-list {
   list-style-type: none;

--- a/content/assets/css/_application.scss
+++ b/content/assets/css/_application.scss
@@ -32,7 +32,6 @@ h2 {
 .marker {
   margin: 20px 0;
   padding: 15px;
-  border-left: 3px solid #eee;
 }
 
 .marker :first-child {
@@ -44,38 +43,59 @@ h2 {
 }
 
 .marker-callout {
-  $color: #dddddd;
-  border-color: $color;
-  background-color: #fdf7f7;
-  color: darken($color, 15%);
+  background: lighten($callout-color, 32%);
+  color: darken($callout-color, 15%);
+  p {
+    &:first-child {
+      &:before {
+        margin-right: 10px;
+        content: "\f06a";
+        font-family: FontAwesome;
+      }
+    }
+  }
 
   a {
     text-decoration: underline;
-    color: darken($color, 15%);
+    color: darken($callout-color, 15%);
   }
 }
 
 .marker-note {
-  $color: #5bc0de;
-  border-color: $color;
-  background-color: #f4f8fa;
-  color: darken($color, 15%);
+  background: lighten($accent-color, 50%);
+  color: lighten($accent-color, 10%);
+  p {
+    &:first-child {
+      &:before {
+        margin-right: 10px;
+        content: "\f05a";
+        font-family: FontAwesome;
+      }
+    }
+  }
 
   a {
     text-decoration: underline;
-    color: darken($color, 15%);
+    color: darken($accent-color, 15%);
   }
 }
 
 .marker-warning {
-  $color: #f0ad4e;
-  border-color: $color;
-  background-color: #fcf8f2;
-  color: darken($color, 15%);
+  background: lighten($warning-color, 32%);
+  color: darken($warning-color, 15%);
+  p {
+    &:first-child {
+      &:before {
+        margin-right: 10px;
+        content: "\f071";
+        font-family: FontAwesome;
+      }
+    }
+  }
 
   a {
     text-decoration: underline;
-    color: darken($color, 15%);
+    color: darken($warning-color, 15%);
   }
 }
 

--- a/content/assets/css/_application.scss
+++ b/content/assets/css/_application.scss
@@ -156,8 +156,6 @@ h2 {
 
 // Make the first title of the page more prominent.
 #main > h1 {
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-
   // .page-header
   padding-bottom: 9px;
   margin: 40px 0 20px;
@@ -175,8 +173,6 @@ h2 {
 #sidebar .sidebar-title {
   margin-top: 25px;
   margin-bottom: 15px;
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-weight: 400;
 }
 
 

--- a/content/assets/css/_colors.scss
+++ b/content/assets/css/_colors.scss
@@ -1,0 +1,1 @@
+$accent-color: #4248AF;

--- a/content/assets/css/_colors.scss
+++ b/content/assets/css/_colors.scss
@@ -1,1 +1,3 @@
-$accent-color: #4248AF;
+$accent-color: #4248Af;
+$warning-color: #f0ad4e;
+$callout-color: #9b9b9b;

--- a/content/assets/css/_template.scss
+++ b/content/assets/css/_template.scss
@@ -36,12 +36,6 @@ h5 {
   background: #242424 no-repeat center center;
   padding: 10px 0;
   color: #fff;
-
-  // gradient shadow before the content
-  border-bottom: 1px solid #ffffff;
-  -webkit-box-shadow: 0 0 20px rgba(#000, 0.7);
-  -moz-box-shadow: 0 0 20px rgba(#000, 0.7);
-  box-shadow: 0 0 20px rgba(#000, 0.7);
 }
 
 

--- a/content/assets/css/_template.scss
+++ b/content/assets/css/_template.scss
@@ -8,7 +8,6 @@ html {
 
 body {
   background-color: #fefefe; // site is using #fafafa
-  line-height: 1.6;
 }
 
 a {

--- a/content/assets/css/_typography.scss
+++ b/content/assets/css/_typography.scss
@@ -5,6 +5,7 @@ body {
   font-family: $font-family;
   font-size: 100%;
   line-height: 1.5;
+  color: #606060;
 }
 
 h1, h2, h3 {
@@ -15,8 +16,9 @@ h1, h2, h3 {
 }
 
 h1 {
-  color: #cc8b00;
+  color: $accent-color;
   font-size: 2em;
+  line-height: 1.3;
   padding-top: $base-unit;
   padding-bottom: $base-unit / 2;
 }
@@ -37,8 +39,20 @@ p {
   padding-bottom: $base-unit;
 }
 
+a {
+  color: $accent-color;
+}
+
 .marker {
   p {
     padding-bottom: 0;
+  }
+}
+
+#toc {
+  &:before {
+    margin-right: 10px;
+    content: "\f02e";
+    font-family: FontAwesome;
   }
 }

--- a/content/assets/css/_typography.scss
+++ b/content/assets/css/_typography.scss
@@ -1,6 +1,44 @@
+$base-unit: 1.5em;
 $font-family: "Helvetica Neue", Arial, sans-serif;
 
 body {
   font-family: $font-family;
   font-size: 100%;
+  line-height: 1.5;
+}
+
+h1, h2, h3 {
+  color: #000;
+  font-weight: normal;
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+h1 {
+  color: #cc8b00;
+  font-size: 2em;
+  padding-top: $base-unit;
+  padding-bottom: $base-unit / 2;
+}
+
+h2 {
+  font-size: 1.4em;
+  padding: $base-unit / 2 0;
+}
+
+h3 {
+  font-size: 1em;
+  font-weight: bold;
+  padding-bottom: $base-unit / 2;
+}
+
+p {
+  margin: 0;
+  padding-bottom: $base-unit;
+}
+
+.marker {
+  p {
+    padding-bottom: 0;
+  }
 }

--- a/content/assets/css/_typography.scss
+++ b/content/assets/css/_typography.scss
@@ -1,0 +1,6 @@
+$font-family: "Helvetica Neue", Arial, sans-serif;
+
+body {
+  font-family: $font-family;
+  font-size: 100%;
+}

--- a/content/assets/css/style.scss
+++ b/content/assets/css/style.scss
@@ -3,6 +3,7 @@
 // --------------------------------------------------
 
 @import "mixins";
+@import "colors";
 @import "typography";
 @import "syntax";
 @import "template";

--- a/content/assets/css/style.scss
+++ b/content/assets/css/style.scss
@@ -3,6 +3,7 @@
 // --------------------------------------------------
 
 @import "mixins";
+@import "typography";
 @import "syntax";
 @import "template";
 @import "application";

--- a/layouts/default.html
+++ b/layouts/default.html
@@ -14,7 +14,6 @@
   <link rel="stylesheet" type="text/css" href="/assets/bootstrap/css/bootstrap.css">
   <link rel="stylesheet" type="text/css" href="/assets/css/style.css">
   <link rel="stylesheet" type="text/css" href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css">
-  <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Open+Sans:700,400">
   <!--[if lt IE 9]>
     <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->


### PR DESCRIPTION
This PR improves the readability of the support pages by fixing a few annoyances reported on #87.

### Before
<img width="732" alt="screen shot 2015-10-08 at 9 38 57 am" src="https://cloud.githubusercontent.com/assets/80610/10362017/0193ce32-6dac-11e5-9bd2-571c8c52894b.png">

### After
<img width="951" alt="screen shot 2015-10-08 at 11 00 08 am" src="https://cloud.githubusercontent.com/assets/80610/10362024/0c0f8b6c-6dac-11e5-98d3-14b9bfda0670.png">

### Highlights:

* Matches font stack from main app
* Matches colors from main 
* Clearer headings hierarchy
* Incresed font for easier reading.
