### PR TITLE
Improve ssl certificates

### DIFF
--- a/content/articles/getting-started-ssl-certificates.markdown
+++ b/content/articles/getting-started-ssl-certificates.markdown
@@ -36,7 +36,7 @@ Here's some questions you should be able to answer:
 - What is the [appropriate common name](/articles/ssl-certificate-hostname/) for your case?
 - Check the web server documentation to understand if you need a [custom CSR](/articles/what-is-csr/).
 
-**You are not required to transfer or host a domain with us to purchase an SSL certificate**. You can purchase an SSL certificate for a domain, even if the domain is hosted elsewhere or registered with another registrar. You can read the [purchase section](/articles/purchasing-ssl-certificates/) of our help page for more information.
+**You are not required to transfer or host a domain with us to purchase an SSL certificate**. You can purchase an SSL certificate for a domain, even if the domain is hosted elsewhere or registered with another registrar. Read the [ordering section](/articles/purchasing-ssl-certificates#order) of the article explaing SSL purchasing for more information.
 
 Feel free to [contact us](https://dnsimple.com/contact) if you can't find the answer to any of the questions above, or if you have any doubt.
 

--- a/content/articles/getting-started-ssl-certificates.markdown
+++ b/content/articles/getting-started-ssl-certificates.markdown
@@ -36,7 +36,7 @@ Here's some questions you should be able to answer:
 - What is the [appropriate common name](/articles/ssl-certificate-hostname/) for your case?
 - Check the web server documentation to understand if you need a [custom CSR](/articles/what-is-csr/).
 
-You'll also need a dnsimple account. **You are not required to transfer or host a domain with us to purchase an SSL certificate**. You can purchase an SSL certificate for a domain, even if the domain is hosted elsewhere or registered with another registrar.
+**You are not required to transfer or host a domain with us to purchase an SSL certificate**. You can purchase an SSL certificate for a domain, even if the domain is hosted elsewhere or registered with another registrar. You can read the [purchase section](/articles/purchasing-ssl-certificates/) of our help page for more information.
 
 Feel free to [contact us](https://dnsimple.com/contact) if you can't find the answer to any of the questions above, or if you have any doubt.
 

--- a/content/articles/getting-started-ssl-certificates.markdown
+++ b/content/articles/getting-started-ssl-certificates.markdown
@@ -36,6 +36,8 @@ Here's some questions you should be able to answer:
 - What is the [appropriate common name](/articles/ssl-certificate-hostname/) for your case?
 - Check the web server documentation to understand if you need a [custom CSR](/articles/what-is-csr/).
 
+You'll also need a dnsimple account. **You are not required to transfer or host a domain with us to purchase an SSL certificate**. You can purchase an SSL certificate for a domain, even if the domain is hosted elsewhere or registered with another registrar.
+
 Feel free to [contact us](https://dnsimple.com/contact) if you can't find the answer to any of the questions above, or if you have any doubt.
 
 ## Purchasing the SSL certificate {#purchase}

--- a/content/articles/purchasing-ssl-certificates.markdown
+++ b/content/articles/purchasing-ssl-certificates.markdown
@@ -25,7 +25,7 @@ To purchase an SSL certificate you need a DNSimple account. In order to finalize
 
 **You are not required to transfer or host a domain with us to purchase an SSL certificate**. You can purchase an SSL certificate for a domain, even if the domain is hosted elsewhere or registered with another registrar.
 
-Please be sure you comply with the all the [technical requirements](/articles/getting-started-ssl-certificates/#requirements) in our [Getting Started with SSL Certificates](/articles/getting-started-ssl-certificates/)page before purchasing the certificate.
+Please be sure you comply with the all the [technical requirements](/articles/getting-started-ssl-certificates/#requirements) in our [Getting Started with SSL Certificates](/articles/getting-started-ssl-certificates/) page before purchasing the certificate.
 
 # Steps
 

--- a/content/articles/purchasing-ssl-certificates.markdown
+++ b/content/articles/purchasing-ssl-certificates.markdown
@@ -19,12 +19,13 @@ DNSimple provides an SSL certificate interface you can use to purchase a new SSL
 All DNSimple SSL certificates are valid for one year from their issue date. Sixty days before the certificate expires you will begin receiving renewal notices.
 
 
-## Requirements
+## Purchase requirements
 
 To purchase an SSL certificate you need a DNSimple account. In order to finalize the purchase, our system requires the account to be subscribed to a DNSimple plan, however you can unsubscribe later on once the certificate is successfully purchased and issued.
 
 **You are not required to transfer or host a domain with us to purchase an SSL certificate**. You can purchase an SSL certificate for a domain, even if the domain is hosted elsewhere or registered with another registrar.
 
+Please be sure you comply with the all the [technical requirements](/articles/getting-started-ssl-certificates/#requirements) in our [Getting Started with SSL Certificates](/articles/getting-started-ssl-certificates/)page before purchasing the certificate.
 
 # Steps
 


### PR DESCRIPTION
The goal of this pull request is to make more clear to a client all the requirements required in order to purchase. Specifically the getting started page did not mention about the business requirements and it pointed straight to a link for support questions. Adding information on the business requirements in that page will provide the client this information too.

Also I have clarified that the requirements in the Purchasing a SSL certificate webpage are purchase requirements and pointed back to the technical requirements.