### PR TITLE
Styling the "steps" section.

### DIFF
--- a/content/assets/css/_application.scss
+++ b/content/assets/css/_application.scss
@@ -123,7 +123,7 @@ h2 {
   background: lighten($accent-color, 50%);
   color: lighten($accent-color, 10%);
 
-  p {
+  > p {
     &:first-child {
       &:before {
         margin-right: 10px;

--- a/content/assets/css/_application.scss
+++ b/content/assets/css/_application.scss
@@ -120,8 +120,12 @@ h2 {
 .section-steps {
   margin-bottom: $base-unit;
   padding: $base-unit / 2;
-  background: lighten($accent-color, 50%);
-  color: lighten($accent-color, 10%);
+  border-top: 5px solid #eee;
+  border-bottom: 5px solid #eee;
+
+  a {
+    text-decoration: underline;
+  }
 
   > p {
     &:first-child {

--- a/content/assets/css/_application.scss
+++ b/content/assets/css/_application.scss
@@ -117,10 +117,21 @@ h2 {
 // Sections are special part of the article with special formatting.
 // Sections don't apply to the entire page, they are just part of the article.
 
-#main .section-steps {
-  font-size: 90%;
-  margin-top: 30px;
-  margin-bottom: 30px;
+.section-steps {
+  margin-bottom: $base-unit;
+  padding: $base-unit / 2;
+  background: lighten($accent-color, 50%);
+  color: lighten($accent-color, 10%);
+
+  p {
+    &:first-child {
+      &:before {
+        margin-right: 10px;
+        content: "\f085";
+        font-family: FontAwesome;
+      }
+    }
+  }
 
   li {
     margin-top: 5px;


### PR DESCRIPTION
This PR fixes the styles section for "steps". Based on #111.

### Before
<img width="989" alt="screen shot 2015-10-08 at 9 20 58 pm" src="https://cloud.githubusercontent.com/assets/80610/10377234/7ef2ccd8-6e02-11e5-8237-90acc0d081ac.png">
### Now
<img width="983" alt="screen shot 2015-10-08 at 9 19 24 pm" src="https://cloud.githubusercontent.com/assets/80610/10377224/72000284-6e02-11e5-98f2-a6d5492f2efe.png">
