### PR TITLE
Only one email category

### DIFF
--- a/content/articles/dkim-record.markdown
+++ b/content/articles/dkim-record.markdown
@@ -3,7 +3,7 @@ title: DKIM records
 excerpt: This article explains how DKIM records work.
 categories:
 - DNS
-- Email
+- Emails
 ---
 
 # DKIM Records


### PR DESCRIPTION
Based on #126. Fixes a typo so we have only one "Emails" category.