### PR TITLE
Optimize only images that need it

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ task :compile do
 end
 
 desc "Publish to S3"
-task :publish => [:compile, :search] do
+task :publish => [:compile, :search, :imgoptim] do
   puts "Publishing to S3"
   puts `s3_website push`
   puts "Published"

--- a/Rakefile
+++ b/Rakefile
@@ -82,7 +82,11 @@ task :imgoptim do
                                jpegtran: false,
                                svgo: false)
 
-  image_optim.optimize_images!(Dir['output/files/*.*']) do |file|
-    puts "Compressing #{file}"
+  puts "Searching for images to optimize..."
+  image_optim.optimize_images!(Dir['output/files/*.*']) do |unoptimized, optimized|
+    if optimized
+      puts "Optimized #{optimized}"
+    end
   end
+  puts "All images optimized!"
 end


### PR DESCRIPTION
This PR is based on the conversation on https://github.com/aetrion/dnsimple-support/commit/7b012e29ddb5964a647f1f5c0024da77bce1ef9e. The `imgoptim` rake task only optimizes images that need it.

Example with 2 consecutive runs:
```
➜  dnsimple-support git:(master) ✗ rake imgoptim
Searching for images to optimize...
Optimized output/files/autorenew-1.png
Optimized output/files/autorenew-2.png
All images optimized!

# Second run
➜  dnsimple-support git:(master) ✗ rake imgoptim
Searching for images to optimize...
All images optimized!
```

It takes a few seconds (~12s on my machine) to search for images to optimize, it should be faster than optimizing everything like we did before.

@weppos test it out and see if you like it. If we decide to run this against the `content` folder, it would work as well.